### PR TITLE
chore: promote jx-rails-quickstart-3 to version 0.0.2

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -3,5 +3,6 @@ helmfiles:
 - path: helmfiles/jx/helmfile.yaml
 - path: helmfiles/secret-infra/helmfile.yaml
 - path: helmfiles/tekton-pipelines/helmfile.yaml
+- path: helmfiles/jx-production/helmfile.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -1,0 +1,11 @@
+filepath: ""
+namespace: jx-production
+repositories:
+- name: dev
+  url: https://bucketrepo-jx.jenkinsx.sandbox.lib.umd.edu
+releases:
+- chart: dev/jx-rails-quickstart-3
+  version: 0.0.2
+  name: jx-rails-quickstart-3
+templates: {}
+renderedvalues: {}


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge

-----
# jx-rails-quickstart-3

## Changes in version 0.0.2

### Chores

* release 0.0.2 (jenkins-x-bot)
* add variables (jenkins-x-bot)

### Other Changes

These commits did not use [Conventional Commits](https://conventionalcommits.org/) formatted messages:

* Fix internal port (Mohamed Abdul Rasheed)
* Update README.md (lib-ssdr-jenkins)
