### PR TITLE
chore: promote jx-rails-quickstart-3 to version 0.0.4

### DIFF
--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -5,7 +5,7 @@ repositories:
   url: https://bucketrepo-jx.jenkinsx.sandbox.lib.umd.edu
 releases:
 - chart: dev/jx-rails-quickstart-3
-  version: 0.0.3
+  version: 0.0.4
   name: jx-rails-quickstart-3
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge

-----
# jx-rails-quickstart-3

## Changes in version 0.0.4

### Chores

* release 0.0.4 (jenkins-x-bot)
* add variables (jenkins-x-bot)

### Other Changes

These commits did not use [Conventional Commits](https://conventionalcommits.org/) formatted messages:

* Updated ping message (David P. Steelman)
